### PR TITLE
Workaround to fix build failures on windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(cmake/pods.cmake)
 include(cmake/lcmtypes.cmake)
 lcmtypes_build(C_AGGREGATE_HEADER bot_core.h CPP_AGGREGATE_HEADER bot_core.hpp)
 
-# TODO
-#add_subdirectory(java)
-
+# TODO: Get building in Win32 again
+if(NOT WIN32)
+  add_subdirectory(java)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,6 @@ include(cmake/pods.cmake)
 include(cmake/lcmtypes.cmake)
 lcmtypes_build(C_AGGREGATE_HEADER bot_core.h CPP_AGGREGATE_HEADER bot_core.hpp)
 
-add_subdirectory(java)
+# TODO
+#add_subdirectory(java)
 

--- a/cmake/lcmtypes.cmake
+++ b/cmake/lcmtypes.cmake
@@ -467,7 +467,7 @@ endfunction()
 
 macro(lcmtypes_build)
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(LCM REQUIRED lcm)
+    pkg_check_modules(LCM lcm)
     
     #find lcm-gen (it may be in the install path)
     find_program(LCM_GEN_EXECUTABLE lcm-gen ${EXECUTABLE_OUTPUT_PATH} ${EXECUTABLE_INSTALL_PATH})


### PR DESCRIPTION
- Made lcm not REQUIRED
- Disabled java portion
