### PR TITLE
add include for cmake_parse_arguments

### DIFF
--- a/cmake/lcmtypes.cmake
+++ b/cmake/lcmtypes.cmake
@@ -82,6 +82,8 @@
 
 cmake_minimum_required(VERSION 2.8.3) # for the CMakeParseArguments macro
 
+include(CMakeParseArguments)
+
 # Policy settings to prevent warnings on 2.6 but ensure proper operation on
 # 2.4.
 if(COMMAND cmake_policy)


### PR DESCRIPTION
this should fix the remaining build issues we've seen on windows.  thanks @billhoffman.
