### PR TITLE
Make Java not required (or skip gracefully)

### DIFF
--- a/cmake/lcmtypes.cmake
+++ b/cmake/lcmtypes.cmake
@@ -423,6 +423,12 @@ function(add_java_lcmtype lcmtype)
     return()
   endif()
 
+  find_package(Java)
+  if (NOT Java_FOUND)
+    message(WARNING "Java not found, not building Java LCM-types or extensions")
+    return()
+  endif()
+
   get_filename_component(lcmtype ${lcmtype} ABSOLUTE)
   get_filename_component(lcmtype_we ${lcmtype} NAME_WE)
   get_package_name(${lcmtype})

--- a/cmake/lcmtypes.cmake
+++ b/cmake/lcmtypes.cmake
@@ -256,6 +256,12 @@ function(lcmtypes_build_java)
     return()
   endif()
 
+  find_package(Java)
+  if (NOT Java_FOUND)
+    message(WARNING "Java not found, not building Java LCM-types or extensions")
+    return()
+  endif()
+
   find_lcmtypes(_msgs)
   foreach(_msg ${_msgs})
     add_java_lcmtype(${_msg})
@@ -420,12 +426,6 @@ endfunction()
 
 function(add_java_lcmtype lcmtype)
   if (NOT LCM_FOUND)
-    return()
-  endif()
-
-  find_package(Java)
-  if (NOT Java_FOUND)
-    message(WARNING "Java not found, not building Java LCM-types or extensions")
     return()
   endif()
 


### PR DESCRIPTION
@jhoare After your PR #3 to build on Windows, Java changed from being not-required to required. This breaks some of our builds on systems that do not have Java. This PR would check whether Java is installed and simply return the add_java_lcmtype() instead of failing due to the find_package(Java REQUIRED). I am wondering, does this have any adverse effect on Drake's Windows build use case?
