### PR TITLE
Fix aggregated header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ set(POD_NAME bot2-core)
 include(cmake/pods.cmake)
 
 include(cmake/lcmtypes.cmake)
-lcmtypes_build(C_AGGREGATE_HEADER bot_core.h CPP_AGGREGATE_HEADER bot_core.hpp)
+lcmtypes_build(C_AGGREGATE_HEADER bot_core CPP_AGGREGATE_HEADER bot_core)
 
 add_subdirectory(java)
-


### PR DESCRIPTION
The cmake/lcmtypes.cmake automatically appends .h and .hpp. Setting it again in CMakeLists causes the double ending .hpp.hpp and .h.h resulting in compilation errors left and right

(discovered by @simalpha when trying to compile her merged branch)
