### PR TITLE
Fix Java build

### DIFF
--- a/cmake/lcmtypes.cmake
+++ b/cmake/lcmtypes.cmake
@@ -257,7 +257,7 @@ function(lcmtypes_build_java)
   endif()
 
   find_package(Java)
-  if (NOT Java_FOUND)
+  if (NOT JAVA_FOUND)
     message(WARNING "Java not found, not building Java LCM-types or extensions")
     return()
   endif()

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -27,6 +27,11 @@ string(STRIP ${LCM_JAR} LCM_JAR)
 # where is lcmtypes_bot2-core.jar?
 #set(bot2_core_jar ${CMAKE_INSTALL_PREFIX}/share/java/lcmtypes_bot2-core.jar)
 
+if(NOT LCMTYPES_JAR)
+    message(WARNING "lcmtypes jar not found, not building bot-spy extensions")
+    return()
+endif()
+
 if (WIN32)
 	set(classpath "${src_dir}\;${LCM_JAR}\;${CMAKE_CURRENT_BINARY_DIR}/../${LCMTYPES_JAR}.jar")
 else()


### PR DESCRIPTION
- The fix from #6 did not work on all machines. This one will.
- Building the bot-spy extensions failed with a add_dependency failure when it couldn't find the lcmtypes jar file. This is resolved now as well
