### PR TITLE
Fix C library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,6 @@ set(POD_NAME bot2-core)
 include(cmake/pods.cmake)
 
 include(cmake/lcmtypes.cmake)
-lcmtypes_build(C_AGGREGATE_HEADER bot_core CPP_AGGREGATE_HEADER bot_core JARNAME lcmtypes_bot2-core)
+lcmtypes_build(C_AGGREGATE_HEADER bot_core CPP_AGGREGATE_HEADER bot_core JARNAME lcmtypes_bot2-core C_LIBNAME bot2-core_lcmtypes)
 
 add_subdirectory(java)


### PR DESCRIPTION
One more knock-on effect from changing lcmtypes.cmake - the library name changed as well and broke code when trying to link on clean build systems where there wasn't a remnant library lying around.
