### PR TITLE
Revert "Fix C library name"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,6 @@ set(POD_NAME bot2-core)
 include(cmake/pods.cmake)
 
 include(cmake/lcmtypes.cmake)
-lcmtypes_build(C_AGGREGATE_HEADER bot_core CPP_AGGREGATE_HEADER bot_core JARNAME lcmtypes_bot2-core C_LIBNAME bot2-core_lcmtypes)
+lcmtypes_build(C_AGGREGATE_HEADER bot_core CPP_AGGREGATE_HEADER bot_core JARNAME lcmtypes_bot2-core)
 
 add_subdirectory(java)


### PR DESCRIPTION
Reverting since this did not achieve its goal and we are currently using a fork with reverted CMake files. I'm step by step debugging what causes the issue and will follow up (cf. #12)

Reverts openhumanoids/bot_core_lcmtypes#11
