### PR TITLE
import viewer control types from drake

### DIFF
--- a/lcmtypes/bot_core_viewer_command_t.lcm
+++ b/lcmtypes/bot_core_viewer_command_t.lcm
@@ -1,0 +1,17 @@
+package bot_core;
+
+struct viewer_command_t
+{
+  int8_t command_type;
+  string command_data;
+
+  // enum for viewer command type
+  const int8_t STATUS           = 0;
+  const int8_t LOAD_MODEL       = 1;
+  const int8_t LOAD_RENDERER    = 2;
+  const int8_t SHUTDOWN         = 3;
+  const int8_t START_RECORDING  = 4;
+  const int8_t STOP_RECORDING   = 5;
+  const int8_t LOAD_TERRAIN     = 6;
+  const int8_t SET_TERRAIN_TRANSFORM = 7;
+}

--- a/lcmtypes/bot_core_viewer_draw_t.lcm
+++ b/lcmtypes/bot_core_viewer_draw_t.lcm
@@ -1,0 +1,12 @@
+package bot_core;
+
+struct viewer_draw_t
+{
+  int64_t timestamp;
+
+  int32_t num_links;
+  string link_name[num_links];
+  int32_t robot_num[num_links];
+  float position[num_links][3];
+  float quaternion[num_links][4];
+}

--- a/lcmtypes/bot_core_viewer_geometry_data_t.lcm
+++ b/lcmtypes/bot_core_viewer_geometry_data_t.lcm
@@ -1,0 +1,24 @@
+package bot_core;
+
+struct viewer_geometry_data_t
+{
+  int8_t type;
+
+  // enum for geometry type
+  const int8_t BOX          = 1;
+  const int8_t SPHERE       = 2;
+  const int8_t CYLINDER     = 3;
+  const int8_t MESH         = 4;
+  const int8_t CAPSULE      = 5;
+  const int8_t ELLIPSOID    = 6;
+
+
+  float position[3];
+  float quaternion[4];
+  float color[4];
+
+  string string_data;
+
+  int32_t num_float_data;
+  float float_data[num_float_data];
+}

--- a/lcmtypes/bot_core_viewer_link_data_t.lcm
+++ b/lcmtypes/bot_core_viewer_link_data_t.lcm
@@ -1,0 +1,10 @@
+package bot_core;
+
+struct viewer_link_data_t
+{
+  string name;
+  int32_t robot_num;
+    
+  int32_t num_geom;
+  viewer_geometry_data_t geom[num_geom];  
+}

--- a/lcmtypes/bot_core_viewer_load_robot_t.lcm
+++ b/lcmtypes/bot_core_viewer_load_robot_t.lcm
@@ -1,0 +1,7 @@
+package bot_core;
+
+struct viewer_load_robot_t
+{
+  int32_t num_links;
+  viewer_link_data_t link[num_links];  
+}


### PR DESCRIPTION
This brings in all the viewer-related types, which previously lived only inside Drake. It's needed to support https://github.com/RobotLocomotion/director/issues/273
