### PR TITLE
Update to latest LCM CMake infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ project(bot2-core)
 cmake_minimum_required(VERSION 3.1)
 
 include(CMakePackageConfigHelpers)
+include(GenerateExportHeader)
 
 find_package(PythonInterp)
 find_package(Java)
@@ -10,6 +11,18 @@ if(JAVA_FOUND)
   include(UseJava)
 endif()
 
+# Enable ELF hidden visibility
+set(CMAKE_C_VISIBILITY_PRESET "hidden")
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
+# Enable PIC
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # TODO remove when minimum CMake >= 3.7
 if(CMAKE_VERSION VERSION_LESS 3.7)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -17,8 +30,6 @@ endif()
 
 find_package(lcm REQUIRED)
 include(${LCM_USE_FILE})
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(lcmtypes)
 add_subdirectory(java)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(bot2-core)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 
 include(CMakePackageConfigHelpers)
 
@@ -17,6 +17,8 @@ endif()
 
 find_package(lcm REQUIRED)
 include(${LCM_USE_FILE})
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(lcmtypes)
 add_subdirectory(java)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 project(bot2-core)
 cmake_minimum_required(VERSION 2.8.12)
 
+include(CMakePackageConfigHelpers)
+
+find_package(PythonInterp)
+find_package(Java)
+
+if(JAVA_FOUND)
+  include(UseJava)
+endif()
+
 # TODO remove when minimum CMake >= 3.7
 if(CMAKE_VERSION VERSION_LESS 3.7)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(Java)
 if(NOT JAVA_FOUND)
   message(STATUS "Java not found: not building Java LCM-SPY plugins")
   return()
@@ -9,7 +8,6 @@ if(NOT TARGET lcm-java)
 endif()
 
 message(STATUS "Found Java and lcm-java: building Java LCM-SPY plugins")
-include(UseJava)
 
 set(src_dir ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(jar_fname lcmspy_plugins_bot2.jar)

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -12,6 +12,7 @@ if(JAVA_FOUND AND TARGET lcm-java)
 endif()
 
 lcm_wrap_types(
+  C_EXPORT bot_core_lcmtypes
   C_SOURCES c_sources
   C_HEADERS c_install_headers
   CPP_HEADERS cpp_install_headers
@@ -59,6 +60,8 @@ lcm_wrap_types(
 )
 
 lcm_add_library(lcmtypes_bot2-core C ${c_sources} ${c_install_headers})
+generate_export_header(lcmtypes_bot2-core
+  BASE_NAME bot_core_lcmtypes)
 target_include_directories(lcmtypes_bot2-core INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 if(PYTHONINTERP_FOUND)
   set(python_args PYTHON_SOURCES python_install_sources)
 endif()
-if(JAVA_FOUND)
+if(JAVA_FOUND AND TARGET lcm-java)
   set(java_args JAVA_SOURCES java_sources)
 endif()
 
@@ -87,26 +87,30 @@ if(PYTHONINTERP_FOUND)
 endif()
 
 if(JAVA_FOUND)
-  add_jar(lcmtypes_bot2-core-jar
-    OUTPUT_NAME lcmtypes_bot2-core
-    INCLUDE_JARS lcm-java
-    SOURCES ${java_sources}
-  )
+  if(NOT TARGET lcm-java)
+    message(STATUS "lcm-java not found: not building Java LCM type bindings")
+  else()
+    add_jar(lcmtypes_bot2-core-jar
+      OUTPUT_NAME lcmtypes_bot2-core
+      INCLUDE_JARS lcm-java
+      SOURCES ${java_sources}
+    )
 
-  install_jar(lcmtypes_bot2-core-jar share/java)
+    install_jar(lcmtypes_bot2-core-jar share/java)
 
-  set(BOT2-CORE_INCLUDE_JAVA
-    "include(\${CMAKE_CURRENT_LIST_DIR}/bot2-coreJavaTargets.cmake)"
-  )
-  export_jars(
-    FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}JavaTargets.cmake
-    TARGETS lcmtypes_bot2-core-jar
-  )
-  install_jar_exports(
-    FILE ${PROJECT_NAME}JavaTargets.cmake
-    DESTINATION ${CONFIG_INSTALL_DIR}
-    TARGETS lcmtypes_bot2-core-jar
-  )
+    set(BOT2-CORE_INCLUDE_JAVA
+      "include(\${CMAKE_CURRENT_LIST_DIR}/bot2-coreJavaTargets.cmake)"
+    )
+    export_jars(
+      FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}JavaTargets.cmake
+      TARGETS lcmtypes_bot2-core-jar
+    )
+    install_jar_exports(
+      FILE ${PROJECT_NAME}JavaTargets.cmake
+      DESTINATION ${CONFIG_INSTALL_DIR}
+      TARGETS lcmtypes_bot2-core-jar
+    )
+  endif()
 endif()
 
 configure_package_config_file(

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -58,21 +58,19 @@ lcm_wrap_types(
   bot_core_viewer_load_robot_t.lcm
 )
 
-add_library(lcmtypes_bot2-core ${c_sources})
+lcm_add_library(lcmtypes_bot2-core C ${c_sources} ${c_install_headers})
 target_include_directories(lcmtypes_bot2-core INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-target_link_libraries(lcmtypes_bot2-core lcm)
-set_target_properties(lcmtypes_bot2-core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+lcm_add_library(lcmtypes_bot2-core-cpp CPP ${cpp_install_headers})
+target_include_directories(lcmtypes_bot2-core-cpp INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 lcm_install_headers(
   ${c_install_headers}
   ${cpp_install_headers}
   DESTINATION include/lcmtypes
 )
-
-add_library(lcmtypes_bot2-core-cpp INTERFACE)
-target_include_directories(lcmtypes_bot2-core-cpp INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 install(TARGETS lcmtypes_bot2-core lcmtypes_bot2-core-cpp
   EXPORT ${PROJECT_NAME}Targets

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -1,8 +1,3 @@
-find_package(PythonInterp)
-find_package(Java)
-
-include(CMakePackageConfigHelpers)
-
 if(WIN32)
   set(CONFIG_INSTALL_DIR CMake)
 else()
@@ -92,8 +87,6 @@ if(PYTHONINTERP_FOUND)
 endif()
 
 if(JAVA_FOUND)
-  include(UseJava)
-
   add_jar(lcmtypes_bot2-core-jar
     OUTPUT_NAME lcmtypes_bot2-core
     INCLUDE_JARS lcm-java

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -17,7 +17,7 @@ if(JAVA_FOUND)
 endif()
 
 lcm_wrap_types(
-  C_SOURCES sources
+  C_SOURCES c_sources
   C_HEADERS c_install_headers
   CPP_HEADERS cpp_install_headers
   CREATE_C_AGGREGATE_HEADER
@@ -63,7 +63,7 @@ lcm_wrap_types(
   bot_core_viewer_load_robot_t.lcm
 )
 
-add_library(lcmtypes_bot2-core ${sources})
+add_library(lcmtypes_bot2-core ${c_sources})
 target_include_directories(lcmtypes_bot2-core INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 target_link_libraries(lcmtypes_bot2-core lcm)

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -64,13 +64,20 @@ lcm_wrap_types(
 )
 
 add_library(lcmtypes_bot2-core ${sources})
+target_include_directories(lcmtypes_bot2-core INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 target_link_libraries(lcmtypes_bot2-core lcm)
 set_target_properties(lcmtypes_bot2-core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-install(FILES ${c_install_headers} DESTINATION include/lcmtypes)
-install(FILES ${cpp_install_headers} DESTINATION include/lcmtypes/bot_core)
+lcm_install_headers(
+  ${c_install_headers}
+  ${cpp_install_headers}
+  DESTINATION include/lcmtypes
+)
 
 add_library(lcmtypes_bot2-core-cpp INTERFACE)
+target_include_directories(lcmtypes_bot2-core-cpp INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 install(TARGETS lcmtypes_bot2-core lcmtypes_bot2-core-cpp
   EXPORT ${PROJECT_NAME}Targets


### PR DESCRIPTION
Clean up the build logic somewhat, and pull in the latest goodies from upstream. In particular, we now export decorate the bindings (so shared libraries on Windows are possible, as is using ELF hidden symbol visibility, which is turned on in this PR). Also, check if `lcm-java` actually exists before trying to build the Java bindings (which require it).
