### PR TITLE
Vi catkin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # bot_core_lcmtypes
 bot_core_lcmtypes contains lcmtypes for common sensor signals - such as images, lidar, joint states, imus, point clouds
+
+
+## Catkin
+bot_core_lcmtypes now contains a catkin package. Please add/remove any/all lcm types to the catkin cmake file (```catkin/bot_core_lcmtypes/CMakeLists.txt```)

--- a/catkin/bot_core_lcmtypes/CMakeLists.txt
+++ b/catkin/bot_core_lcmtypes/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(bot_core_lcmtypes)
+
+find_package(catkin REQUIRED COMPONENTS
+  lcm_ros
+)
+
+catkin_package(
+  #INCLUDE_DIRS include/${PROJECT_NAME}
+  LIBRARIES lcmtypes_${PROJECT_NAME}
+  CATKIN_DEPENDS lcm_ros
+#  DEPENDS system_lib
+)
+
+FindLCM(../../)
+
+AddLCM(
+bot_core_atlas_command_t
+bot_core_force_torque_t
+bot_core_gps_data_t
+bot_core_gps_satellite_info_list_t
+bot_core_gps_satellite_info_t
+bot_core_image_metadata_t
+bot_core_images_t
+bot_core_image_sync_t
+bot_core_image_t
+bot_core_ins_t
+bot_core_joint_angles_t
+bot_core_joint_state_t
+bot_core_kvh_raw_imu_batch_t
+bot_core_kvh_raw_imu_t
+bot_core_planar_lidar_t
+bot_core_pointcloud2_t
+bot_core_pointcloud_t
+bot_core_pointfield_t
+bot_core_pose_t
+bot_core_position_3d_t
+bot_core_quaternion_t
+bot_core_raw_t
+bot_core_rigid_transform_t
+bot_core_robot_state_t
+bot_core_robot_urdf_t
+bot_core_sensor_status_t
+bot_core_six_axis_force_torque_array_t
+bot_core_six_axis_force_torque_t
+bot_core_system_status_t
+bot_core_twist_t
+bot_core_utime_t
+bot_core_vector_3d_t
+)
+
+AddSpyLCM(bot2 ../../java/src/bot2_spy/ImagePlugin.java ../../java/src/bot2_spy/PlanarLidarPlugin.java)
+
+GenerateLCM()

--- a/catkin/bot_core_lcmtypes/CMakeLists.txt
+++ b/catkin/bot_core_lcmtypes/CMakeLists.txt
@@ -2,14 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bot_core_lcmtypes)
 
 find_package(catkin REQUIRED COMPONENTS
-  lcm_ros
+lcm_catkin
 )
 
 catkin_package(
-  #INCLUDE_DIRS include/${PROJECT_NAME}
-  LIBRARIES lcmtypes_${PROJECT_NAME}
-  CATKIN_DEPENDS lcm_ros
-#  DEPENDS system_lib
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS lcm_catkin
 )
 
 FindLCM(../../)

--- a/catkin/bot_core_lcmtypes/package.xml
+++ b/catkin/bot_core_lcmtypes/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>bot_core_lcmtypes</name>
+  <version>0.0.0</version>
+  <description>The bot_core_lcmtypes package</description>
+  <maintainer email="v.ivan@ed.ac.uk">Vladimir Ivan</maintainer>
+
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>lcm_ros</depend>
+</package>

--- a/catkin/bot_core_lcmtypes/package.xml
+++ b/catkin/bot_core_lcmtypes/package.xml
@@ -7,5 +7,5 @@
 
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>lcm_ros</depend>
+  <depend>lcm_catkin</depend>
 </package>


### PR DESCRIPTION
Adds support for compiling as a catkin package (this depends on [lcm_catkin](https://github.com/ipab-slmc/lcm_catkin)).
Keeps existing pods buildsystem.