### PR TITLE
Fix build tree exports

### DIFF
--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -123,7 +123,7 @@ configure_package_config_file(
 
 # Exported targets for build directory
 export(
-  TARGETS lcmtypes_bot2-core
+  TARGETS lcmtypes_bot2-core lcmtypes_bot2-core-cpp
   FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
 )
 


### PR DESCRIPTION
Include `lcmtypes_bot2-core-cpp` in also the build tree exports. (It was only being included in the installed exports.)